### PR TITLE
Update paramdb read

### DIFF
--- a/pyPRMS/__init__.py
+++ b/pyPRMS/__init__.py
@@ -14,6 +14,7 @@ from .parameters.ParameterNetCDF import ParameterNetCDF
 from .parameters.ValidParams import ValidParams
 from .cbh.CbhAscii import CbhAscii
 from .cbh.CbhNetcdf import CbhNetcdf
+from .Streamflow import Streamflow
 
 
 from .version import __author__, __author_email__, __version__
@@ -37,4 +38,5 @@ __all__ = ['control',
            'ParamDb',
            'ParamDbRegion',
            'ParameterNetCDF',
+           'Streamflow',
            'ValidParams']

--- a/pyPRMS/parameters/ParamDb.py
+++ b/pyPRMS/parameters/ParamDb.py
@@ -3,6 +3,9 @@
 import os
 import pandas as pd     # type: ignore
 from typing import cast, Optional
+import io
+import pkgutil
+import xml.etree.ElementTree as xmlET
 # from typing import Any,  Union, Dict, List, OrderedDict as OrderedDictType, Set
 
 from ..prms_helpers import read_xml
@@ -27,6 +30,12 @@ class ParamDb(ParameterSet):
         self.__paramdb_dir = paramdb_dir
         self.__verbose = verbose
 
+        # When restricted is false the package parameter xml file is used
+        # otherwise the parameter database xml file is used.
+        # TODO: 2023-03-28 not currently settable on init; not sure if we even need an option
+        #       or if the package xml should always be used.
+        self.__restricted = False
+
         # Read the parameters from the parameter database
         self._read()
 
@@ -36,11 +45,22 @@ class ParamDb(ParameterSet):
 
         # Get the parameters available from the parameter database
         # Returns a dictionary of parameters and associated units and types
-        global_params_file = f'{self.__paramdb_dir}/{PARAMETERS_XML}'
-        global_dimens_file = f'{self.__paramdb_dir}/{DIMENSIONS_XML}'
 
-        # Read in the parameters.xml and dimensions.xml file
-        params_root = read_xml(global_params_file)
+        # Read the parameters XML file
+        if self.__restricted:
+            global_params_file = f'{self.__paramdb_dir}/{PARAMETERS_XML}'
+            params_root = read_xml(global_params_file)
+        else:
+            # Read the full list of possible parameters
+            res = pkgutil.get_data('pyPRMS', 'xml/parameters.xml')
+
+            assert res is not None
+            xml_fh = io.StringIO(res.decode('utf-8'))
+            self.__xml_tree = xmlET.parse(xml_fh)
+            params_root = self.__xml_tree.getroot()
+
+        # Read in the dimensions.xml file
+        global_dimens_file = f'{self.__paramdb_dir}/{DIMENSIONS_XML}'
         dimens_root = read_xml(global_dimens_file)
 
         # Populate the global dimensions from the xml file
@@ -85,4 +105,5 @@ class ParamDb(ParameterSet):
                     print(err_txt)
                     self.parameters.remove(xml_param_name)
             else:
-                print(f'WARNING: {xml_param_name}, ParamDb file does not exist; skipping')
+                pass
+                # print(f'WARNING: {xml_param_name}, ParamDb file does not exist; skipping')

--- a/pyPRMS/parameters/Parameter.py
+++ b/pyPRMS/parameters/Parameter.py
@@ -199,9 +199,16 @@ class Parameter(object):
                   f'values; using first value only.')
             data_np = np.array(data_np[0], ndmin=1)
         else:
-            err_txt = f'{self.name}: Number of dimensions for new data ({data_np.ndim}) ' + \
-                      f'doesn\'t match old ({self.ndims})'
-            raise IndexError(err_txt)
+            if data_np.size == 1:
+                # Incoming data is scalar but it should be an array; expand to the expected dims/size
+                new_sizes = [vv.size for vv in self.dimensions.values()]
+                data_np = np.broadcast_to(data_np, new_sizes)
+                print(f'{self.name}: Scalar was broadcast to {new_sizes}')
+            else:
+                print(f'{self.size=}; {data_np.size=}')
+                err_txt = f'{self.name}: Number of dimensions for new data ({data_np.ndim}) ' + \
+                          f'doesn\'t match old ({self.ndims})'
+                raise IndexError(err_txt)
 
         if self.__data is None:
             self.__data = data_np

--- a/pyPRMS/xml/parameters.xml
+++ b/pyPRMS/xml/parameters.xml
@@ -2634,7 +2634,7 @@
         <units>none</units>
         <desc>The NHM index of the downstream segment</desc>
         <help>NHM index of downstream segment to which the segment streamflow flows, for segments that do not flow to another segment enter 0</help>
-        <minimum>-11</minimum>
+        <minimum>1</minimum>
         <maximum>1000000</maximum>
         <default>0</default>
         <modules>
@@ -2818,23 +2818,6 @@
         </modules>
         <dimensions>
             <dimension name="npoigages">
-                <position>1</position>
-            </dimension>
-        </dimensions>
-    </parameter>
-    <parameter name="tosegment_nhm">
-        <type>I</type>
-        <units>none</units>
-        <desc>National Hydrologic Model downstream segment ID</desc>
-        <help>National Model Hydrologic downstream segment ID</help>
-        <minimum>0</minimum>
-        <maximum>9999999</maximum>
-        <default>0</default>
-        <modules>
-            <module>setup_param</module>
-        </modules>
-        <dimensions>
-            <dimension name="nsegment">
                 <position>1</position>
             </dimension>
         </dimensions>


### PR DESCRIPTION
Default the parameter database read routine to use the package parameter.xml instead of the parameter database xml file.
The Parameter class data setter now automatically expands scalar data to the dimensionality of the pre-existing parameters.