### PR TITLE
Update supported Python versions through 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,10 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -115,12 +115,12 @@ jobs:
       #     swap-storage: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python-version}}
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pyPRMS
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.13"]
 
     steps:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyPRMS"
 description = "Python library for Precipitation-Runoff Modeling System"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 license = {file = "LICENSE"}
 authors = [{name = "Parker Norton", email = "pnorton@usgs.gov"}, ]
 maintainers = [{name = "Parker Norton", email = "pnorton@usgs.gov"}, ]
@@ -30,7 +30,8 @@ dependencies = ["cartopy",
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx-book-theme",
-    "xarray", ]
+    "xarray",
+    "zarr<3"]
 
 [project.optional-dependencies]
 dev = ["mypy",

--- a/tests/func/test_Cbh.py
+++ b/tests/func/test_Cbh.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 from pathlib import Path
-from distutils import dir_util
+import shutil
 
 from pyPRMS import Cbh
 from pyPRMS import ControlFile
@@ -22,7 +22,7 @@ def datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
 
     return tmpdir
 


### PR DESCRIPTION
Update pyPRMS to support Python versions through 3.14. Removed deprecated distutils from test_Cbh.py.