### PR TITLE
Improve Dimension.py documentation and input validation

### DIFF
--- a/pyPRMS/dimensions/Dimension.py
+++ b/pyPRMS/dimensions/Dimension.py
@@ -134,14 +134,18 @@ class Dimension(object):
     def size(self, value: int | str):
         """Set the size of the dimension.
 
-        :param value: Size of the dimension
-        :raises ValueError: if dimension size is not a positive integer
+        :param value: Size of the dimension (int or numeric string)
+        :raises ValueError: if value is a float, cannot be converted to int, or is negative
         """
 
         if isinstance(value, float):
-            raise ValueError(f'{self.name} size cannot be a float value')
+            raise ValueError(f'{self.name}: size cannot be a float value')
 
-        value = int(value)
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            raise ValueError(f'{self.name}: size must be an integer or numeric string, got {type(value).__name__!r}')
+
         def_value = self.meta.get('default', 0)
 
         if value < 0:

--- a/pyPRMS/dimensions/Dimension.py
+++ b/pyPRMS/dimensions/Dimension.py
@@ -13,11 +13,19 @@ class Dimension(object):
         A dimension has a name and a size associated with it.
 
         :param name: The name of the dimension
-        :param size: The size of the dimension
-        :param strict: Enforce use of valid dimensions metadata
+        :param meta: Dimension metadata. When ``strict=True`` this should be the
+            full dimensions metadata dict (keyed by dimension name); the sub-dict
+            for *name* will be extracted automatically. When ``strict=False`` this
+            should be the sub-dict of metadata for this specific dimension (or
+            ``None`` for an empty metadata dict).
+        :param size: The size of the dimension. If None, the size is set from
+            the ``default`` value in the metadata (or 0 if not present).
+        :param strict: When True, *meta* is required and must contain an entry
+            for *name*. When False, *meta* is used as-is without validation.
         """
 
         self.__name = name
+        self.__strict = strict
 
         if meta is None:
             if strict:
@@ -32,7 +40,7 @@ class Dimension(object):
                     raise ValueError(f'`{self.name}` does not exist in metadata')
             else:
                 if isinstance(meta, dict):
-                    # Assume we have a dictionary of metadata for this dimension
+                    # Assume we have a dictionary of metadata for just this dimension
                     self.meta = meta
 
         if size is None:
@@ -65,7 +73,7 @@ class Dimension(object):
         :returns: Dimension size
 
         :raises ValueError: if type of parameter is not an integer
-        :raises ValeuError: if parameter is not a positive integer
+        :raises ValueError: if parameter is not a positive integer
         """
 
         # Augment in-place addition so the instance minus a number results
@@ -80,7 +88,7 @@ class Dimension(object):
 
         :returns: string with name and size of dimension
         """
-        return f"Dimension(name='{self.name}', meta={self.meta}, size={self.size}, strict=False)"
+        return f"Dimension(name='{self.name}', meta={self.meta}, size={self.size}, strict={self.__strict})"
 
     def __str__(self) -> str:
         """Return friendly string representation of dimension
@@ -97,7 +105,11 @@ class Dimension(object):
         return outstr
 
     @property
-    def is_fixed(self):
+    def is_fixed(self) -> bool:
+        """Whether this dimension has a fixed size that cannot be changed.
+
+        :returns: True if dimension is fixed, otherwise False
+        """
         return self.meta.get('is_fixed', False)
 
     @property

--- a/tests/func/test_Dimension.py
+++ b/tests/func/test_Dimension.py
@@ -131,7 +131,7 @@ class TestDimension:
 
     def test_dimension_repr(self, metadata_instance):
         """The __repr__ should produce code to instantiate a Dimension object"""
-        str_cmp = "Dimension(name='nhru', meta={'description': 'Number of HRUs', 'size': 1, 'default': 1, 'is_fixed': False}, size=1, strict=False)"
+        str_cmp = "Dimension(name='nhru', meta={'description': 'Number of HRUs', 'size': 1, 'default': 1, 'is_fixed': False}, size=1, strict=True)"
 
         adim = Dimension(name='nhru', meta=metadata_instance, size=1)
         repr_str = repr(adim)


### PR DESCRIPTION
# Improve Dimension.py documentation and input validation

## Summary

Improves `Dimension.py` with better documentation, corrected annotations, and hardened input validation for the `size` setter.

## Changes

### Documentation and annotations
- Clarify `__init__` docstring: document the `meta` parameter contract for strict vs non-strict modes
- Fix `__isub__` docstring typo: "ValeuError" → "ValueError"
- Add `-> bool` return type annotation and docstring to `is_fixed` property

### Bug fixes
- Fix `__repr__` to reflect the actual `strict` value used at construction instead of hardcoding `False`
- Update corresponding test expectation

### Input validation
- Harden `size` setter with try/except around `int()` conversion
- Non-numeric strings, `None`, lists, and other invalid types now produce clear error messages instead of raw Python conversion errors
- numpy integer types (`np.int32`, `np.int64`) continue to work correctly
- All invalid inputs still raise `ValueError` (backward compatible)

## Testing

All 290 tests pass.