### PR TITLE
Clean up and harden Dimensions.py

### DIFF
--- a/pyPRMS/dimensions/Dimensions.py
+++ b/pyPRMS/dimensions/Dimensions.py
@@ -33,14 +33,6 @@ class Dimensions(object):
                 # TODO: 20230707 PAN - is adhoc metadata a useful idea?
                 self.metadata = metadata
 
-        # if metadata is not None:
-        #     self.metadata = metadata['dimensions']
-
-        # if self.metadata is not None:
-        #     for cdim, cvals in self.metadata.items():
-        #         self.add(name=cdim, meta=self.metadata)
-        #
-
     def __contains__(self, name: str) -> bool:
         """Check if a dimension exists.
 
@@ -136,7 +128,6 @@ class Dimensions(object):
             dim_sub = xmlET.SubElement(dims_xml, 'dimension')
             dim_sub.set('name', kk)
             xmlET.SubElement(dim_sub, 'size').text = str(vv.size)
-            # dim_sub.set('size', str(vv.size))
         return dims_xml
 
     def add(self, name: str, size: int | None = None):
@@ -228,9 +219,6 @@ class ParamDimensions(Dimensions):
             dim_sub.set('name', kk)
             xmlET.SubElement(dim_sub, 'position').text = str(self.get_position(kk)+1)
             xmlET.SubElement(dim_sub, 'size').text = str(vv.size)
-
-            # dim_sub.set('position', str(self.get_position(kk)+1))
-            # dim_sub.set('size', str(vv.size))
         return dims_xml
 
     def add(self, name: str, size: int | None = None):

--- a/pyPRMS/dimensions/Dimensions.py
+++ b/pyPRMS/dimensions/Dimensions.py
@@ -1,6 +1,7 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
 import xml.etree.ElementTree as xmlET
 
 from .Dimension import Dimension
@@ -99,12 +100,12 @@ class Dimensions(object):
         return self.__dimensions.items()
 
     @property
-    def dimensions(self) -> dict[str, Dimension]:
-        """Get ordered dictionary of Dimension objects.
+    def dimensions(self) -> MappingProxyType[str, Dimension]:
+        """Get read-only view of Dimension objects.
 
-        :returns: OrderedDict of Dimension objects
+        :returns: Read-only mapping of dimension names to Dimension objects
         """
-        return self.__dimensions
+        return MappingProxyType(self.__dimensions)
 
     @property
     def ndim(self) -> int:

--- a/pyPRMS/dimensions/Dimensions.py
+++ b/pyPRMS/dimensions/Dimensions.py
@@ -197,6 +197,8 @@ class ParamDimensions(Dimensions):
     of individual dimensions to 2.
     """
 
+    MAX_DIMS: int = 2
+
     def __init__(self, metadata: MetaDataType | None = None,
                  verbose: bool = False,
                  strict: bool = True):
@@ -229,8 +231,8 @@ class ParamDimensions(Dimensions):
         :param size: Size of the dimension
         """
 
-        if self.ndim == 2:
-            raise ValueError('A parameter cannot have more than two dimensions.')
+        if self.ndim == self.MAX_DIMS:
+            raise ValueError(f'A parameter cannot have more than {self.MAX_DIMS} dimensions.')
 
         # Restrict number of dimensions for parameters
         super().add(name, size)
@@ -241,7 +243,7 @@ class ParamDimensions(Dimensions):
         :param index: The 0-based position of the dimension
         :returns: Size of the dimension
 
-        :raises ValueError: if index is greater than number dimensions for the parameter
+        :raises IndexError: if index is greater than number of dimensions for the parameter
         """
 
         if index < len(self.dimensions.items()):
@@ -251,13 +253,20 @@ class ParamDimensions(Dimensions):
     def get_position(self, name: str) -> int:
         """Get 0-based index position of a dimension.
 
+        .. deprecated:: Use :meth:`index` instead.
+
         :param name: name of the dimension
-
-        :returns: Zero-based Index position of dimension
+        :returns: Zero-based index position of dimension
         """
+        return self.index(name)
 
-        # TODO: method name should be index() ??
-        return list(self.dimensions.keys()).index(name)
+    def index(self, name: str) -> int:
+        """Get 0-based index position of a dimension.
+
+        :param name: name of the dimension
+        :returns: Zero-based index position of dimension
+        """
+        return list(self.keys()).index(name)
 
     def tostructure(self) -> dict[str, dict[str, int]]:
         """Get dictionary structure of the dimensions.


### PR DESCRIPTION
# Clean up and harden Dimensions.py

## Summary

Removes dead code, protects internal state from external mutation, and improves the `ParamDimensions` API.

## Changes

### Dead code removal
- Remove obsolete commented-out initialization logic in `Dimensions.__init__`
- Remove commented-out XML attribute alternatives in both `xml` properties

### Encapsulation
- `dimensions` property now returns a `MappingProxyType` (read-only view) instead of the raw internal dict
- Prevents external code from bypassing `add()`/`remove()` by directly mutating the dict
- All read operations (`keys`, `values`, `items`, `[]`, `in`, iteration) continue to work unchanged

### ParamDimensions improvements
- Add `MAX_DIMS = 2` class constant to make the dimension limit explicit and configurable
- Add `index()` method (more Pythonic name for getting a dimension's position)
- Keep `get_position()` as a deprecated alias for backward compatibility
- Fix `get_dimsize_by_index` docstring: documented `:raises ValueError:` but actually raises `IndexError`

## Testing

All 290 tests pass.