### PR TITLE
Refactor/input module improvements

### DIFF
--- a/pyPRMS/input/DataFile.py
+++ b/pyPRMS/input/DataFile.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-import pandas as pd   # type: ignore
+import pandas as pd
 
 from collections.abc import Sequence
 

--- a/pyPRMS/input/DataFile.py
+++ b/pyPRMS/input/DataFile.py
@@ -20,7 +20,7 @@ COMMENT = '//'
 # NA_VALS_DEFAULT = ('-99.0', '-999.0')
 
 
-class DataFile(object):
+class DataFile:
     """Class for working with PRMS ASCII input data files
     """
 
@@ -44,8 +44,8 @@ class DataFile(object):
         self.__missing = missing
         self.filename = filename
         self.__verbose = verbose
-        self.metadata = metadata['data_file']
-        self.parameters = parameters
+        self._metadata = metadata['data_file']
+        self._parameters = parameters
 
         self.__header = ''   # data file header from first line of the file
         self.__station_meta_header: list[str] = []   # header lines before station metadata (if provided)
@@ -89,7 +89,7 @@ class DataFile(object):
 
         global con
 
-        if self.parameters is None:
+        if self._parameters is None:
             # Resolve the units for each variable from the file units if possible
             for cvar in self.__input_vars.values():
                 if '_units' in cvar.metadata['units']:
@@ -159,6 +159,22 @@ class DataFile(object):
     def station_meta_header(self):
         return self.__station_meta_header
 
+    @property
+    def metadata(self) -> dict:
+        """Metadata for the data file variables.
+
+        :returns: Metadata dictionary
+        """
+        return self._metadata
+
+    @property
+    def parameters(self) -> Parameters | None:
+        """Parameters object associated with this data file.
+
+        :returns: Parameters object or None
+        """
+        return self._parameters
+
     def resolve_units(self):
         """Adjust units metadata for input variables that have an initial units value of
         precip_units, runoff_units, or temp_units.
@@ -166,7 +182,7 @@ class DataFile(object):
         :returns: None
         """
 
-        selected_units = self.parameters.user_defined_units
+        selected_units = self._parameters.user_defined_units
         for cvar in self.__input_vars.values():
             if cvar.metadata['units'] in selected_units:
                 cvar.metadata['units'] = selected_units[cvar.metadata['units']]
@@ -258,7 +274,7 @@ class DataFile(object):
             # Add data to each input variable
             self._add_variable_data()
 
-    def write_ascii(self, filename: str) -> None:
+    def write_ascii(self, filename: str | os.PathLike) -> None:
         """Write dataframe to ASCII formatted file.
 
         This routine always writes out missing data as -999
@@ -402,7 +418,7 @@ class DataFile(object):
         for cvar, cmeta in self.__input_vars_intern.items():
             self.__input_vars[cvar] = InputVariable(name=cvar,
                                                     data=self.__data_raw.iloc[:, st_idx:(st_idx + cmeta['size'])],
-                                                    metadata=self.metadata,
+                                                    metadata=self._metadata,
                                                     station_metadata=self.__df_file_metadata.iloc[st_idx:(st_idx + cmeta['size'])],
                                                     file_units=cmeta.get('file_units', None))
             # self.__input_vars_intern[cvar]['data'] = self.__data_raw.iloc[:, st_idx:(st_idx + cmeta['size'])]

--- a/pyPRMS/input/DataFile.py
+++ b/pyPRMS/input/DataFile.py
@@ -218,10 +218,10 @@ class DataFile(object):
 
                 if len(line) == 0:
                     continue
-                if line[0:len(COMMENT)] == COMMENT:
+                if line.startswith(COMMENT):
                     header_info.append(line)
                     continue
-                if line[0:len(DATA_SEP)] == DATA_SEP:
+                if line.startswith(DATA_SEP):
                     break
 
                 # Get the input variable name and total size for the variable
@@ -310,14 +310,14 @@ class DataFile(object):
         line = next(it)
 
         try:
-            while line[0:len(STATION_START)] != STATION_START:
+            while not line.startswith(STATION_START):
                 line = next(it)
 
             # Process the station information
             self.__station_meta_header.append(line.strip())
 
             line = next(it)
-            if line[0:len('// ID')].lower() == '// id':
+            if line.lower().startswith('// id'):
                 # Process the station information
                 self.__station_meta_header.append(line.strip())
                 meta_vars = line.replace(COMMENT, '').strip().split()
@@ -328,7 +328,7 @@ class DataFile(object):
 
                 # Loop through the variables and read the station information for each one
                 for kk, vv in self.__input_vars_intern.items():
-                    if line[0:len(HEADER_SEP)] == HEADER_SEP:
+                    if line.startswith(HEADER_SEP):
                         continue
 
                     for sz in range(vv['size']):
@@ -375,11 +375,11 @@ class DataFile(object):
                         self.__df_file_metadata.loc[len(self.__df_file_metadata)] = [f'{sz+1}', kk]
 
         try:
-            while line[0:len(UNITS_START)] != UNITS_START:
+            while not line.startswith(UNITS_START):
                 line = next(it)
 
             # Process the units
-            while line[0:len(HEADER_SEP)] != HEADER_SEP:
+            while not line.startswith(HEADER_SEP):
                 for elem in (line.replace(UNITS_START, '').replace(COMMENT, '').replace(' ', '').split(',')):
                     try:
                         cvar, cunits = elem.split('=')

--- a/pyPRMS/input/DataFile.py
+++ b/pyPRMS/input/DataFile.py
@@ -17,7 +17,6 @@ STATION_START = '// Station'
 UNITS_START = '// Unit:'
 DATA_SEP = '####'
 COMMENT = '//'
-# NA_VALS_DEFAULT = ('-99.0', '-999.0')
 
 
 class DataFile:
@@ -421,7 +420,6 @@ class DataFile:
                                                     metadata=self._metadata,
                                                     station_metadata=self.__df_file_metadata.iloc[st_idx:(st_idx + cmeta['size'])],
                                                     file_units=cmeta.get('file_units', None))
-            # self.__input_vars_intern[cvar]['data'] = self.__data_raw.iloc[:, st_idx:(st_idx + cmeta['size'])]
             st_idx += cmeta['size']
 
     def _data_column_names(self) -> list[str]:

--- a/pyPRMS/input/DataFile.py
+++ b/pyPRMS/input/DataFile.py
@@ -58,8 +58,36 @@ class DataFile(object):
         self.__input_vars_intern: dict[str, dict[str, int | str | list[str]]] = {}
 
         self.__data_raw: pd.DataFrame | None = None
+        self.__data_combined: pd.DataFrame | None = None
 
         self.load_file(self.filename)
+        self._resolve_units()
+
+    @classmethod
+    def from_file(cls, filename: str | os.PathLike,
+                  metadata: MetaDataType,
+                  parameters: Parameters | None = None,
+                  missing: Sequence[str] = ('-99.9', '-999.0', '-9999.0'),
+                  verbose: bool = False) -> DataFile:
+        """Create a DataFile by reading from an ASCII data file.
+
+        This is equivalent to calling ``DataFile(...)`` directly but makes the
+        I/O step explicit.
+
+        :param filename: name of data file
+        :param metadata: Metadata for the data file variables
+        :param parameters: Parameters object
+        :param missing: list of missing values
+        :param verbose: output debugging information
+        :returns: DataFile instance
+        """
+
+        return cls(filename, metadata, parameters=parameters, missing=missing, verbose=verbose)
+
+    def _resolve_units(self):
+        """Resolve units for input variables using parameters or file metadata."""
+
+        global con
 
         if self.parameters is None:
             # Resolve the units for each variable from the file units if possible
@@ -71,23 +99,44 @@ class DataFile(object):
             # Resolve the units of each variable from the parameter file
             self.resolve_units()
 
+    def __repr__(self) -> str:
+        """Concise string representation for debugging.
+
+        :returns: String representation of the DataFile object
+        """
+
+        n_vars = len(self.__input_vars_intern)
+        if self.__data_raw is not None:
+            start = self.__data_raw.index.min()
+            end = self.__data_raw.index.max()
+            return f"DataFile(filename={self.filename!r}, variables={n_vars}, period={start} to {end})"
+        return f"DataFile(filename={self.filename!r}, variables={n_vars})"
+
     @property
     def data(self) -> pd.DataFrame:
-        """Pandas dataframe of the data file for each input variable
+        """Pandas dataframe of the data file for each input variable.
+
+        The result is cached after the first access. Call :meth:`invalidate_cache`
+        if the underlying variable data has been modified.
 
         :returns: Pandas dataframe of the data file
         """
-        first = True
-        for cvar in self.input_variables.keys():
-            tmp_df = self.get(cvar).data.copy()
-            tmp_df.rename(columns=self.get(cvar).full_column_names, inplace=True)
+        if self.__data_combined is None:
+            frames = []
+            for cvar in self.input_variables.keys():
+                tmp_df = self.get(cvar).data.copy()
+                tmp_df.rename(columns=self.get(cvar).full_column_names, inplace=True)
+                frames.append(tmp_df)
+            self.__data_combined = pd.concat(frames, axis=1)
+        return self.__data_combined
 
-            if first:
-                self.__data_raw = tmp_df
-                first = False
-            else:
-                self.__data_raw = pd.concat([self.__data_raw, tmp_df], axis=1)
-        return self.__data_raw
+    def invalidate_cache(self) -> None:
+        """Invalidate the cached combined DataFrame.
+
+        Call this after modifying individual input variable data so that the
+        next access to :attr:`data` rebuilds the combined frame.
+        """
+        self.__data_combined = None
 
     @property
     def file_metadata(self) -> pd.DataFrame:
@@ -228,26 +277,25 @@ class DataFile(object):
         df['minute'] = df.index.minute
         df['second'] = df.index.second
 
-        outhdl = open(filename, 'w')
-        outhdl.write(f'{self.__header}\n')
-        outhdl.write(f'{HEADER_SEP*15}\n')
+        with open(filename, 'w') as outhdl:
+            outhdl.write(f'{self.__header}\n')
+            outhdl.write(f'{HEADER_SEP*15}\n')
 
-        for xx in self.__station_meta_header:
-            outhdl.write(f'{xx}\n')
+            for xx in self.__station_meta_header:
+                outhdl.write(f'{xx}\n')
 
-        for kk in self.__input_vars.keys():
-            for mstr in self.get(kk).file_metadata_str:
-                outhdl.write(f'{mstr}\n')
+            for kk in self.__input_vars.keys():
+                for mstr in self.get(kk).file_metadata_str:
+                    outhdl.write(f'{mstr}\n')
 
-        outhdl.write(f'{HEADER_SEP*15}\n')
+            outhdl.write(f'{HEADER_SEP*15}\n')
 
-        for kk in self.__input_vars.keys():
-            outhdl.write(f'{kk} {self.get(kk).num_stations}\n')
+            for kk in self.__input_vars.keys():
+                outhdl.write(f'{kk} {self.get(kk).num_stations}\n')
 
-        outhdl.write(f'{DATA_SEP*15}\n')
+            outhdl.write(f'{DATA_SEP*15}\n')
 
-        df.to_csv(outhdl, sep=' ', columns=out_order, index=False, header=False, na_rep='-999', encoding=None)
-        outhdl.close()
+            df.to_csv(outhdl, sep=' ', columns=out_order, index=False, header=False, na_rep='-999', encoding=None)
 
     def _add_file_metadata(self, header_info: list[str]):
         """Add file metadata from data file.

--- a/pyPRMS/input/InputVariable.py
+++ b/pyPRMS/input/InputVariable.py
@@ -29,6 +29,14 @@ class InputVariable(object):
         else:
             self.metadata = metadata[name]
 
+    def __repr__(self) -> str:
+        """Concise string representation for debugging.
+
+        :returns: String representation of the InputVariable object
+        """
+
+        return f"InputVariable(name={self.__name!r}, stations={self.num_stations}, rows={len(self.data)})"
+
     def __str__(self) -> str:
         """Pretty-print string representation of the data file input variable information.
 
@@ -65,7 +73,7 @@ class InputVariable(object):
 
         col_names = {}
         for xx in data_in.columns:
-            col_names[xx] = xx.split('_')[1]
+            col_names[xx] = xx.split('_', 1)[1]
 
         self.__data = data_in.copy()
         self.__data.rename(columns=col_names, inplace=True)

--- a/pyPRMS/input/InputVariable.py
+++ b/pyPRMS/input/InputVariable.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pandas as pd   # type: ignore
 
 
-class InputVariable(object):
+class InputVariable:
     """Class for working with input variables."""
 
     def __init__(self, name: str,
@@ -85,7 +85,7 @@ class InputVariable(object):
         self.__data.rename(columns=col_names, inplace=True)
 
     @property
-    def file_metadata_str(self) -> list:
+    def file_metadata_str(self) -> list[str]:
         """Returns the input variable file metadata string.
 
         :returns: List of input variable file metadata strings
@@ -101,7 +101,7 @@ class InputVariable(object):
         return mstr
 
     @property
-    def full_column_names(self) -> dict:
+    def full_column_names(self) -> dict[str, str]:
         col_names = {}
         for xx in self.__data.columns:
             col_names[xx] = f'{self.name}_{xx}'
@@ -134,7 +134,7 @@ class InputVariable(object):
         return self.data.columns.size
 
     @property
-    def stations(self) -> list:
+    def stations(self) -> list[str]:
         """Returns the input variable stations.
 
         :returns: Input variable stations
@@ -142,8 +142,13 @@ class InputVariable(object):
 
         return self.station_metadata.iloc[:, 0].tolist()
 
-    def drop(self, stations: list):
-        """Drop stations from the input variable
+    def drop(self, stations: list[str]):
+        """Drop stations from the input variable.
+
+        .. note::
+            If this InputVariable belongs to a DataFile, call
+            :meth:`DataFile.invalidate_cache` after dropping stations so
+            the combined DataFrame is rebuilt on next access.
         """
 
         # Drop the station data

--- a/pyPRMS/input/InputVariable.py
+++ b/pyPRMS/input/InputVariable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pandas as pd   # type: ignore
+import pandas as pd
 
 
 class InputVariable:

--- a/pyPRMS/input/InputVariable.py
+++ b/pyPRMS/input/InputVariable.py
@@ -85,18 +85,25 @@ class InputVariable:
         self.__data.rename(columns=col_names, inplace=True)
 
     @property
+    def _id_column(self) -> str:
+        """Return the name of the station ID column in station_metadata.
+
+        The column name varies between files (e.g. 'id', 'ID') so we
+        use the first column which is always the station identifier.
+        """
+        return self.station_metadata.columns[0]
+
+    @property
     def file_metadata_str(self) -> list[str]:
         """Returns the input variable file metadata string.
 
         :returns: List of input variable file metadata strings
         """
 
-        flds = self.station_metadata.columns.tolist()
-        # mstr = [f'// {" ".join(flds)}']
+        id_col = self._id_column
         mstr = []
         for cstn in self.stations:
-            # mstr += f'// {" ".join(df_m.loc[df_m["id"] == cstn].values.tolist()[0])}\n'
-            mstr.append(f'// {" ".join(self.station_metadata.loc[self.station_metadata[flds[0]] == cstn].values.tolist()[0])}')
+            mstr.append(f'// {" ".join(self.station_metadata.loc[self.station_metadata[id_col] == cstn].values.tolist()[0])}')
 
         return mstr
 
@@ -140,7 +147,7 @@ class InputVariable:
         :returns: Input variable stations
         """
 
-        return self.station_metadata.iloc[:, 0].tolist()
+        return self.station_metadata[self._id_column].tolist()
 
     def drop(self, stations: list[str]):
         """Drop stations from the input variable.
@@ -155,5 +162,6 @@ class InputVariable:
         self.data.drop(columns=stations, inplace=True)
 
         # Drop the station metadata
-        self.station_metadata.drop(self.station_metadata[self.station_metadata['id'].isin(stations)].index,
+        id_col = self._id_column
+        self.station_metadata.drop(self.station_metadata[self.station_metadata[id_col].isin(stations)].index,
                                    axis=0, inplace=True)

--- a/pyPRMS/input/InputVariable.py
+++ b/pyPRMS/input/InputVariable.py
@@ -25,9 +25,15 @@ class InputVariable(object):
         self.station_metadata = station_metadata
 
         if 'data_file' in metadata:
-            self.metadata = metadata['data_file'][name]
+            source = metadata['data_file']
         else:
-            self.metadata = metadata[name]
+            source = metadata
+
+        if name not in source:
+            available = list(source.keys())
+            raise ValueError(f"Variable '{name}' not found in metadata. Available: {available}")
+
+        self.metadata = source[name]
 
     def __repr__(self) -> str:
         """Concise string representation for debugging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = ["cartopy",
 [project.optional-dependencies]
 dev = ["mypy",
        "mypy_extensions",
+       "pandas-stubs",
        "pytest",
        "pytest-cov",
        "pytest-xdist",

--- a/tests/func/test_DataFile.py
+++ b/tests/func/test_DataFile.py
@@ -162,3 +162,46 @@ class TestStreamflow:
         datafile_chk = DataFile(chk_filename, metadata=prms_meta, parameters=pdb, missing=('-999.0'), verbose=False)
 
         assert_frame_equal(datafile.data, datafile_chk.data, check_dtype=False)
+
+    def test_datafile_repr(self, datadir):
+        """Test that DataFile.__repr__ returns a useful string."""
+        sf_filename = datadir / 'sf_data_pipestem_bandit'
+
+        prms_meta = MetaData(verbose=False).metadata
+        datafile = DataFile(sf_filename, metadata=prms_meta, verbose=False)
+
+        result = repr(datafile)
+        assert 'DataFile(' in result
+        assert 'variables=1' in result
+        assert 'period=' in result
+
+    def test_input_variable_repr(self, datadir):
+        """Test that InputVariable.__repr__ returns a useful string."""
+        sf_filename = datadir / 'sf_data_pipestem_bandit'
+
+        prms_meta = MetaData(verbose=False).metadata
+        datafile = DataFile(sf_filename, metadata=prms_meta, verbose=False)
+        obs_sf = datafile.get('runoff')
+
+        result = repr(obs_sf)
+        assert 'InputVariable(' in result
+        assert "name='runoff'" in result
+        assert 'stations=1' in result
+        assert 'rows=731' in result
+
+    def test_invalidate_cache(self, datadir):
+        """Test that invalidate_cache forces the data property to rebuild."""
+        sf_filename = datadir / 'sf_data_downsizer'
+
+        prms_meta = MetaData(verbose=False).metadata
+        datafile = DataFile(sf_filename, metadata=prms_meta, verbose=False)
+
+        # First access builds the cache
+        df1 = datafile.data
+        assert df1 is datafile.data  # same object returned on second access
+
+        # Invalidate and verify a new frame is built
+        datafile.invalidate_cache()
+        df2 = datafile.data
+        assert df2 is not df1
+        assert_frame_equal(df1, df2)


### PR DESCRIPTION
## Summary

Refactors `pyPRMS/input/DataFile.py` and `pyPRMS/input/InputVariable.py` to improve readability, correctness, and maintainability.

## Changes

### DataFile.py
- Add `__repr__` showing filename, variable count, and date range
- Cache the combined DataFrame in the `data` property; add `invalidate_cache()` method
- Use context manager (`with` statement) in `write_ascii` to prevent file handle leaks
- Replace all `line[0:len(X)] == X` patterns with `startswith()`
- Add `from_file()` classmethod factory; extract `_resolve_units()` helper
- Remove explicit `object` inheritance
- Make `metadata` and `parameters` private with read-only properties
- Accept `str | os.PathLike` in `write_ascii` for consistency with `load_file`
- Remove commented-out dead code

### InputVariable.py
- Add `__repr__` showing name, station count, and row count
- Fix `data.setter` to use `split('_', 1)` so station IDs with underscores are preserved
- Add metadata validation in `__init__` with a clear `ValueError` on missing keys
- Remove explicit `object` inheritance
- Add `_id_column` property for reliable station ID column access regardless of case
- Add full type annotations to `stations`, `file_metadata_str`, `full_column_names`, and `drop()`
- Document that `drop()` requires `DataFile.invalidate_cache()` afterward

### pyproject.toml
- Add `pandas-stubs` to dev dependencies
- Remove `# type: ignore` from pandas imports in both source files

## Testing

- All 10 existing tests pass (including 4 roundtrip tests across different data file formats)
- 3 new tests added: `test_datafile_repr`, `test_input_variable_repr`, `test_invalidate_cache`